### PR TITLE
Fix wording of permanently closed shops fixme

### DIFF
--- a/components/contribute_form.vue
+++ b/components/contribute_form.vue
@@ -235,7 +235,7 @@ export default {
       const [ lon, lat ] = this.place.geometry.coordinates;
       const tags = {
         opening_hours: this.openingHoursWithoutLockDown ? 'same': undefined,
-        fixme: this.definite_closing === true ? 'This place is definitely closed' : undefined
+        fixme: this.definite_closing === true ? 'This place is permanently closed' : undefined
       };
 
       Object.entries(this.fields).forEach(e => {


### PR DESCRIPTION
The fixme value "This place is definitely closed" does mean "I'm sure it's closed", not "it's closed permanently". It's a french "faux-ami" ;)

This PR changes swap "definitely" for "permanently".