### PR TITLE
Update ja.json

### DIFF
--- a/locales/ja.json
+++ b/locales/ja.json
@@ -351,13 +351,13 @@
   },
   "directory": {
     "regions": {
-      "title": "地方リスト"
+      "title": "都道府県リスト"
     },
     "departements": {
-      "title": "百貨店リスト"
+      "title": "市区町村リスト"
     },
     "communes": {
-      "title": "州リスト"
+      "title": "町字リスト"
     },
     "pois": {
       "link": {


### PR DESCRIPTION
Updated the translation of "directory" lit-trans: 地方行政区分
オブジェ "directory" (地方行政区分)の表記が更新されました

région 地方 → 都道府県 
départements 百貨店 → 市区町村
communes 州 → 町字